### PR TITLE
chore: add onboard desktop id to launchpad hidden list

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-osconfig (2024.01.09) unstable; urgency=medium
+
+  * add onboard to dde-launchpad's excludeAppIdList list
+
+ -- Wang Zichong <wangzichong@deepin.org>  Tue, 09 Jan 2024 16:38:00 +0800
+
 deepin-osconfig (2023.12.22) unstable; urgency=medium
 
   * release 2023.12.22

--- a/files/configs/overrides/dde-launchpad/org.deepin.dde.launchpad.appsmodel/default.json
+++ b/files/configs/overrides/dde-launchpad/org.deepin.dde.launchpad.appsmodel/default.json
@@ -1,0 +1,11 @@
+{
+  "magic": "dsg.config.override",
+  "version": "1.0",
+  "contents": {
+  "excludeAppIdList": {
+    "value": ["onboard.desktop", "onboard-settings.desktop"],
+      "serial": 0,
+      "permission": "readonly"
+    }
+  }
+}


### PR DESCRIPTION
使 launchpad 在 deepin 发行版中默认隐藏 onboard 图标。

Issue:

- https://github.com/linuxdeepin/developer-center/issues/6815

测试建议：升级后，`killall dde-launchpad`，然后直接验证上述 Issue 即可。