### PR TITLE
feat: [filemanager] set the filemanager dconfig

### DIFF
--- a/files/configs/overrides/org.deepin.dde.file-manager/org.deepin.dde.file-manager.plugins/default.json
+++ b/files/configs/overrides/org.deepin.dde.file-manager/org.deepin.dde.file-manager.plugins/default.json
@@ -5,6 +5,9 @@
         "filemanager.blackList": {
             "value": ["dfmplugin-vault"]
         },
+        "desktop.blackList": {
+            "value": []
+        },
         "server.blackList": {
             "value": ["serverplugin-vaultdaemon"]
         }


### PR DESCRIPTION
The Organier plug -in is banned by default.
The community version wants to enable the plug -in, so the plug -in is not required to set up.

Log: add feature of filemanager dconfig
Task: https://pms.uniontech.com/task-view-341993.html