### PR TITLE
chore: release deepin-osconfig 2024.08.06

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-osconfig (2024.08.06) unstable; urgency=medium
+
+  * Add compat DConfig item for launchpad DConfig migration
+
+ -- Wang Zichong <wangzichong@deepin.org>  Tue, 06 Aug 2024 20:29:00 +0800
+
 deepin-osconfig (2024.01.09) unstable; urgency=medium
 
   * add onboard to dde-launchpad's excludeAppIdList list

--- a/files/configs/overrides/org.deepin.dde.shell/org.deepin.ds.launchpad/default.json
+++ b/files/configs/overrides/org.deepin.dde.shell/org.deepin.ds.launchpad/default.json
@@ -1,0 +1,11 @@
+{
+  "magic": "dsg.config.override",
+  "version": "1.0",
+  "contents": {
+  "excludeAppIdList": {
+    "value": ["onboard.desktop", "onboard-settings.desktop"],
+      "serial": 0,
+      "permission": "readonly"
+    }
+  }
+}


### PR DESCRIPTION
Changelog:

  * Add compat DConfig item for launchpad DConfig migration

Log: