### PR TITLE
chore: update override for dock

### DIFF
--- a/files/configs/overrides/org.deepin.dde.shell/org.deepin.ds.dock/default.json
+++ b/files/configs/overrides/org.deepin.dde.shell/org.deepin.ds.dock/default.json
@@ -1,0 +1,11 @@
+{
+  "magic": "dsg.config.override",
+  "version": "1.0",
+  "contents": {
+  "Item_Alignment": {
+    "value": "center",
+      "serial": 0,
+      "permission": "readonly"
+    }
+  }
+}


### PR DESCRIPTION
Item_Alignment  default is left on deepin

pms: BUG-286539