### PR TITLE
fix: 添加 postinst 解决磐石系统更新导致语言环境丢失问题

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-osconfig (2025.01.15) unstable; urgency=medium
+
+  * add postinst.
+
+ -- lichenggang <lichenggang@deepin.org>  Wed, 15 Jan 2025 17:33:34 +0800
+
 deepin-osconfig (2024.08.06) unstable; urgency=medium
 
   * Add compat DConfig item for launchpad DConfig migration

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+LOCALES=(
+en_US
+zh_CN
+zh_TW
+zh_HK
+id_ID
+ms_MY
+cs_CZ
+da_DK
+de_DE
+el_GR
+es_ES
+fr_FR
+hr_HR
+it_IT
+hu_HU
+nl_NL
+pl_PL
+pt_PT
+pt_BR
+ru_RU
+ro_RO
+sk_SK
+fi_FI
+sv_SE
+tr_TR
+uk_UA
+bg_BG
+ja_JP
+ko_KR
+hi_IN
+am_ET
+sr_RS
+ca_ES
+bo_CN
+ug_CN
+en_US
+zh_CN
+zh_TW
+zh_HK
+id_ID
+ms_MY
+cs_CZ
+da_DK
+de_DE
+el_GR
+es_ES
+fr_FR
+hr_HR
+it_IT
+hu_HU
+nl_NL
+pl_PL
+pt_PT
+pt_BR
+ru_RU
+ro_RO
+sk_SK
+fi_FI
+sv_SE
+tr_TR
+uk_UA
+bg_BG
+ja_JP
+ko_KR
+hi_IN
+am_ET
+sr_RS
+ca_ES
+bo_CN
+ug_CN
+)
+
+# Update /etc/locale.gen and generate new locale cache.
+# Or else neither timezone page nor keyboard layout page work well with
+# gettext.
+generate_locale() {
+    for LOCALE_NAME in "${LOCALES[@]}"; do
+        sed -i "s/# \(${LOCALE_NAME}\.UTF-8.*$\)/\1/g" /etc/locale.gen
+    done
+
+    locale-gen
+}
+
+### During the software package installation phase,
+### some time-consuming Chinese character sets will be processed in advance on some software platforms
+generate_extral_locales() {
+    if test -z "$(localedef --list-archive | grep ^zh_CN$)";then
+        localedef -i zh_CN -c -f GB2312 -A /usr/share/locale/locale.alias zh_CN
+    fi
+    if test -z "$(localedef --list-archive | grep ^zh_CN.gb18030$)";then
+        localedef --no-archive -i zh_CN -c -f GB18030 -A /usr/share/locale/locale.alias zh_CN.GB18030
+    fi
+    if test -z "$(localedef --list-archive | grep ^zh_CN.gbk$)";then
+        localedef --no-archive -i zh_CN -c -f GBK -A /usr/share/locale/locale.alias zh_CN.GBK
+    fi
+}
+case "$1" in
+    configure)
+    generate_locale
+    generate_extral_locales
+    ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
  解决磐石系统更新导致语言环境丢失问题

Log: